### PR TITLE
Shot Count Reset Fix

### DIFF
--- a/client/comms/server.js
+++ b/client/comms/server.js
@@ -361,6 +361,7 @@ var Server = function (catalog_) {
       client.assailants = [];
       client.victims = [];
       client.resetLoadouts();
+      announceLoadout(client);
       // todo: when client loadout status is stored on server,
       // reset their magazine etc
     });
@@ -370,7 +371,6 @@ var Server = function (catalog_) {
   function respawnAllClients(){
     worldState.clients.forEach(function(client){
       respawn(client);
-      announceLoadout(client);
     });
   }
 

--- a/client/comms/server.js
+++ b/client/comms/server.js
@@ -90,6 +90,7 @@ var Server = function (catalog_) {
     this.introduceNewPlayer(client);
     updateLeaderboard();
     respawn(client);
+    announceLoadout(client);
   }
 
   this.sendUpdates = function(){
@@ -369,6 +370,7 @@ var Server = function (catalog_) {
   function respawnAllClients(){
     worldState.clients.forEach(function(client){
       respawn(client);
+      announceLoadout(client);
     });
   }
 

--- a/client/player.js
+++ b/client/player.js
@@ -76,7 +76,7 @@ var Player = function (position_, world_) {
 
   this.setLoadout = function(l){
     loadout = l;
-    document.getElementById('snowballCount').innerHTML = loadout.magazine;
+    document.getElementById('snowballCount').innerHTML = loadout.name + ": " + loadout.magazine;
   }
 
   this.isLocked = function(){
@@ -91,7 +91,7 @@ var Player = function (position_, world_) {
       
       loadout.loadStatus = 0;
       loadout.magazine -= 1;
-      document.getElementById('snowballCount').innerHTML = loadout.magazine;
+      document.getElementById('snowballCount').innerHTML = loadout.name + ": " + loadout.magazine;
       return vector;
     }
     return false;


### PR DESCRIPTION
Shot count is reset when the player first loads and at the start of each round, even if the player doesn't change the loadout. Also, now the loadout name is displayed next to the shot count. 