### PR TITLE
respawn and count as death when stuck in block

### DIFF
--- a/client/comms/client.js
+++ b/client/comms/client.js
@@ -31,6 +31,10 @@ var Client = function (world_, scene_) {
     connection.send({updateName:name});
     connection.send({updateColor:color});
 
+    player.whenStuckInBlock(function(){
+      connection.send({stuckInBlock:true});
+    });
+
     conn.on("data", function(data){
       if(data.newPlayer){
         let npd = data.newPlayer;

--- a/client/comms/server.js
+++ b/client/comms/server.js
@@ -76,6 +76,12 @@ var Server = function (catalog_) {
         client.position = new THREE.Vector3(...data.doneMovingTo);
         client.isTeleporting = false;
       }
+      if(data.stuckInBlock){
+        client.sendAnnouncement("you got stuck in a block!");
+        client.assailants.push("stuck");
+        respawn(client);
+        updateLeaderboard();
+      }
       if(data.requestChunk){
         let p = new THREE.Vector3(...data.requestChunk.position);
         sendChunk(client, p);

--- a/client/player.js
+++ b/client/player.js
@@ -17,6 +17,9 @@ var Player = function (position_, world_) {
   this.color = new THREE.Color();
   var playerJustFell = false;
 
+  // call this function when stuck in a block
+  var stuckInBlockFunc = function(){};
+
   var prevTime = performance.now();
 
   var camera = null;
@@ -109,6 +112,10 @@ var Player = function (position_, world_) {
     controls.getObject().position.setX(p.x);
     controls.getObject().position.setY(p.y);
     controls.getObject().position.setZ(p.z);
+  }
+
+  this.whenStuckInBlock = function(f){
+    stuckInBlockFunc = f;
   }
 
   this.isPositionColliding = function(position){
@@ -277,9 +284,7 @@ var Player = function (position_, world_) {
       controls.getObject().position.z = newPos.z;
 
       if (this.isPositionColliding(originalPosition)) {
-        controls.getObject().position.x = originalPosition.x;
-        controls.getObject().position.y = originalPosition.y; // THIS STOPS JUMPING THROUGH CEILINGS
-        controls.getObject().position.z = originalPosition.z;
+        stuckInBlockFunc();
       }
 
       // what was the actual delta in position? this is the actual velocity


### PR DESCRIPTION
in anticipation of loadouts that can create blocks:
when a player inevitably gets stuck in a new block that appears in their world, what should happen?

in this pull request:
* player is alerted: "you got stuck in a block"
* player is respawned
* counts as a death, like falling off the world

how does this make you feel?
I'm thinking that projectiles that place blocks will try not to build where players are, but there could always be a delay in where the server thinks players are vs where they actually are, so there's a good chance people will get stuck even if we try to avoid it.